### PR TITLE
Fix variable names

### DIFF
--- a/libs/algorithms.py
+++ b/libs/algorithms.py
@@ -6,13 +6,13 @@
 #
 
 
-def bubbleSort(list):
-    return list
+def bubbleSort(ls):
+    return ls
 
 
-def insertionSort(list):
-    return list
+def insertionSort(ls):
+    return ls
 
 
-def selectionSort(list):
-    return list
+def selectionSort(ls):
+    return ls

--- a/libs/algorithms.py
+++ b/libs/algorithms.py
@@ -7,12 +7,15 @@
 
 
 def bubbleSort(ls):
-    return ls.copy()
+    ls = ls.copy()
+    return ls
 
 
 def insertionSort(ls):
-    return ls.copy()
+    ls = ls.copy()
+    return ls
 
 
 def selectionSort(ls):
-    return ls.copy()
+    ls = ls.copy()
+    return ls

--- a/libs/algorithms.py
+++ b/libs/algorithms.py
@@ -7,12 +7,12 @@
 
 
 def bubbleSort(ls):
-    return ls
+    return ls.copy()
 
 
 def insertionSort(ls):
-    return ls
+    return ls.copy()
 
 
 def selectionSort(ls):
-    return ls
+    return ls.copy()


### PR DESCRIPTION
The variable `list` overrides one of python's built-in static classes.  It interferes with autocomplete.